### PR TITLE
Fix path handling for Taildrive

### DIFF
--- a/drive/driveimpl/shared/pathutil.go
+++ b/drive/driveimpl/shared/pathutil.go
@@ -23,16 +23,13 @@ const (
 // parts. This is different from path.Split which just splits a path into prefix
 // and suffix.
 //
+// The provided path must already be URL-decoded. CleanAndSplit does not
+// perform any url.PathUnescape calls.
+//
 // If p is empty or contains only path separators, CleanAndSplit returns a slice
 // of length 1 whose only element is "".
 func CleanAndSplit(p string) []string {
-	parts := strings.Split(strings.Trim(path.Clean(p), sepStringAndDot), sepString)
-	for i, part := range parts {
-		if u, err := url.PathUnescape(part); err == nil {
-			parts[i] = u
-		}
-	}
-	return parts
+        return strings.Split(strings.Trim(path.Clean(p), sepStringAndDot), sepString)
 }
 
 // Normalize normalizes the given path (e.g. dropping trailing slashes).

--- a/drive/driveimpl/shared/pathutil.go
+++ b/drive/driveimpl/shared/pathutil.go
@@ -19,17 +19,20 @@ const (
 	sep             = '/'
 )
 
-// CleanAndSplit cleans the provided path p and splits it into its constituent
-// parts. This is different from path.Split which just splits a path into prefix
-// and suffix.
-//
-// The provided path must already be URL-decoded. CleanAndSplit does not
-// perform any url.PathUnescape calls.
+// CleanAndSplit cleans the provided path p, splits it into its constituent
+// parts, and URL-decodes each segment. This is different from path.Split which
+// just splits a path into prefix and suffix.
 //
 // If p is empty or contains only path separators, CleanAndSplit returns a slice
 // of length 1 whose only element is "".
 func CleanAndSplit(p string) []string {
-        return strings.Split(strings.Trim(path.Clean(p), sepStringAndDot), sepString)
+	parts := strings.Split(strings.Trim(path.Clean(p), sepStringAndDot), sepString)
+	for i, part := range parts {
+		if u, err := url.PathUnescape(part); err == nil {
+			parts[i] = u
+		}
+	}
+	return parts
 }
 
 // Normalize normalizes the given path (e.g. dropping trailing slashes).

--- a/drive/driveimpl/shared/pathutil.go
+++ b/drive/driveimpl/shared/pathutil.go
@@ -26,7 +26,13 @@ const (
 // If p is empty or contains only path separators, CleanAndSplit returns a slice
 // of length 1 whose only element is "".
 func CleanAndSplit(p string) []string {
-	return strings.Split(strings.Trim(path.Clean(p), sepStringAndDot), sepString)
+	parts := strings.Split(strings.Trim(path.Clean(p), sepStringAndDot), sepString)
+	for i, part := range parts {
+		if u, err := url.PathUnescape(part); err == nil {
+			parts[i] = u
+		}
+	}
+	return parts
 }
 
 // Normalize normalizes the given path (e.g. dropping trailing slashes).

--- a/drive/driveimpl/shared/pathutil.go
+++ b/drive/driveimpl/shared/pathutil.go
@@ -20,8 +20,10 @@ const (
 )
 
 // CleanAndSplit cleans the provided path p, splits it into its constituent
-// parts, and URL-decodes each segment. This is different from path.Split which
-// just splits a path into prefix and suffix.
+// parts, and URL-decodes each segment. Paths from r.URL.Path may contain
+// percent-encoded directory names, so each segment is unescaped before use.
+// It differs from path.Split which only splits a path into prefix and suffix
+// components.
 //
 // If p is empty or contains only path separators, CleanAndSplit returns a slice
 // of length 1 whose only element is "".

--- a/drive/driveimpl/shared/pathutil_test.go
+++ b/drive/driveimpl/shared/pathutil_test.go
@@ -25,9 +25,6 @@ func TestCleanAndSplit(t *testing.T) {
 		{"a/b/", []string{"a", "b"}},
 		{"/a/b/", []string{"a", "b"}},
 		{"/a/../b", []string{"b"}},
-
-			{"/space%20dir/file.txt", []string{"space dir", "file.txt"}},
-			{"/a%2Fb/c", []string{"a/b", "c"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {

--- a/drive/driveimpl/shared/pathutil_test.go
+++ b/drive/driveimpl/shared/pathutil_test.go
@@ -25,6 +25,9 @@ func TestCleanAndSplit(t *testing.T) {
 		{"a/b/", []string{"a", "b"}},
 		{"/a/b/", []string{"a", "b"}},
 		{"/a/../b", []string{"b"}},
+
+			{"/space%20dir/file.txt", []string{"space dir", "file.txt"}},
+			{"/a%2Fb/c", []string{"a/b", "c"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {

--- a/drive/driveimpl/shared/pathutil_test.go
+++ b/drive/driveimpl/shared/pathutil_test.go
@@ -25,6 +25,8 @@ func TestCleanAndSplit(t *testing.T) {
 		{"a/b/", []string{"a", "b"}},
 		{"/a/b/", []string{"a", "b"}},
 		{"/a/../b", []string{"b"}},
+		{"/space%20dir/file.txt", []string{"space dir", "file.txt"}},
+		{"/a%2Fb/c", []string{"a/b", "c"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- unescape URL path segments when splitting paths
- add tests covering encoded path segments to ensure unescaping

## Testing
- `go test ./drive/...` *(fails before fix)*
- `go test ./drive/...`

------
https://chatgpt.com/codex/tasks/task_e_683f4ab2d9bc832787e48737b8c050a3